### PR TITLE
Bug fix: next timestamp for Pocket get was in milliseconds

### DIFF
--- a/src/PocketAPI.ts
+++ b/src/PocketAPI.ts
@@ -98,7 +98,7 @@ export const getPocketItems = async (
   lastUpdateTimestamp?: UpdateTimestamp
 ): Promise<TimestampedPocketGetItemsResponse> => {
   const GET_ITEMS_URL = "https://getpocket.com/v3/get";
-  const nextTimestamp = Date.now();
+  const nextTimestamp = Math.floor(Date.now() / 1000);
 
   const requestOptions = {
     consumer_key: PLATFORM_CONSUMER_KEYS["mac"],


### PR DESCRIPTION
The timestamp should be in seconds.