### PR TITLE
Fixes for plugin unload/reload

### DIFF
--- a/src/PocketItemListView.tsx
+++ b/src/PocketItemListView.tsx
@@ -24,8 +24,9 @@ export class PocketItemListView extends ItemView {
   }
 
   async onClose() {
-    console.log("onClose");
-    this.plugin.viewManager.removeView(this.id);
+    // view manager can be null when plugin has been unloaded. The unload step
+    // clears all views, so the view does not need to be removed here.
+    this.plugin.viewManager?.removeView(this.id);
   }
 
   getPortal() {

--- a/src/PocketItemStore.ts
+++ b/src/PocketItemStore.ts
@@ -157,3 +157,6 @@ export const openPocketItemStore = async (): Promise<PocketItemStore> => {
   });
   return new PocketItemStore(db);
 };
+
+export const closePocketItemStore = async (pocketItemStore: PocketItemStore) =>
+  await pocketItemStore.db.close();

--- a/src/ViewManager.ts
+++ b/src/ViewManager.ts
@@ -31,12 +31,14 @@ export class ViewManager {
     this.setState(this.views);
     console.log(`views: ${Array.from(this.views.keys())}`);
   }
+
   removeView(viewName: ViewName): void {
     console.log(`Removing view for ${viewName}`);
     this.views = update(this.views, { $remove: [viewName] });
     this.setState(this.views);
     console.log(`views: ${Array.from(this.views.keys())}`);
   }
+
   clearViews(): void {
     console.log(`Clearing views`);
     this.views = update(this.views, { $set: new Map() });


### PR DESCRIPTION
- Pocket item store is properly closed on plugin unload.
- Views are properly killed on plugin onload.