### PR TITLE
Pocket item store onChange handlers should run after clearDatabase call

### DIFF
--- a/src/PocketItemStore.ts
+++ b/src/PocketItemStore.ts
@@ -131,6 +131,7 @@ export class PocketItemStore {
   clearDatabase = async () => {
     await this.db.clear(ITEM_STORE_NAME);
     await this.db.clear(METADATA_STORE_NAME);
+    await this.handleOnChange();
   };
 }
 


### PR DESCRIPTION
This was causing the Pocket item list to not get updated when clicking on the clear local Pocket data button.