### PR TITLE
Fix for bug where multi-word tag converter setting is not set yet

### DIFF
--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -10,6 +10,10 @@ export interface PocketSettings {
   "multi-word-tag-converter"?: MultiWordTagConversion;
 }
 
+const DEFAULT_POCKET_SETTINGS: PocketSettings = {
+  "multi-word-tag-converter": "snake-case",
+};
+
 export type OnSettingsChangeCallback = () => Promise<void>;
 
 export type LoadPocketSettingsFn = () => Promise<PocketSettings>;
@@ -47,7 +51,7 @@ export class SettingsManager {
   }
 
   getSetting(key: keyof PocketSettings) {
-    return this.settings[key];
+    return this.settings[key] ?? DEFAULT_POCKET_SETTINGS[key];
   }
 
   async updateSetting(key: keyof PocketSettings, newValue: any) {

--- a/src/Tags.ts
+++ b/src/Tags.ts
@@ -11,7 +11,13 @@ export const openSearchForTag =
     globalSearch.openGlobalSearch(`tag:${tag}`);
   };
 
-export type MultiWordTagConversion = "snake-case" | "camel-case" | "do-nothing";
+const multiWordTagConversionTypes = [
+  "snake-case",
+  "camel-case",
+  "do-nothing",
+] as const;
+export type MultiWordTagConversion = typeof multiWordTagConversionTypes[number];
+
 export type MultiWordTagConversionFn = (tag: string) => string;
 export const multiWordTagConversions: Map<
   MultiWordTagConversion,
@@ -42,6 +48,11 @@ export interface TagNormalizationChoiceParams {
 export const getTagNormalizer = ({
   multiWordTagConversion,
 }: TagNormalizationChoiceParams): TagNormalizationFn => {
+  if (!multiWordTagConversionTypes.includes(multiWordTagConversion)) {
+    throw new Error(
+      `Invalid multi-word tag conversion type: ${multiWordTagConversion}`
+    );
+  }
   const multiWordTagConverter = multiWordTagConversions.get(
     multiWordTagConversion
   );


### PR DESCRIPTION
The case where the user does not yet have a setting value for the multi-word tag converter was not handled properly, causing the multi-word tag conversion to not be found and then fail silently. Fixed this by adding a check that the conversion setting is valid and adding the default to the settings manager.

Tested that the Pocket item list renders properly and new Pocket item note creation works.

Resolves #57.