### PR TITLE
Fix for incorrect creation of URL to note index for new installs

### DIFF
--- a/src/data/PocketIDB.ts
+++ b/src/data/PocketIDB.ts
@@ -2,7 +2,7 @@ import { IDBPDatabase, IDBPTransaction, openDB } from "idb";
 import log from "loglevel";
 
 const POCKET_IDB_DATABASE_NAME = "pocket_db";
-const POCKET_IDB_VERISION = 5;
+const POCKET_IDB_VERISION = 6;
 
 export const ITEM_STORE_NAME = "items";
 export const METADATA_STORE_NAME = "metadata";

--- a/src/data/URLToPocketItemNoteIndex.ts
+++ b/src/data/URLToPocketItemNoteIndex.ts
@@ -230,18 +230,20 @@ export class URLToPocketItemNoteIndex {
     newVersion,
     tx
   ) => {
-    switch (oldVersion) {
-      case 4:
-        db.createObjectStore(URL_TO_ITEM_NOTE_STORE_NAME, {
-          keyPath: KEY_PATH,
-        });
-        tx.objectStore(URL_TO_ITEM_NOTE_STORE_NAME).createIndex(
-          FILE_PATH_INDEX_PATH,
-          FILE_PATH_INDEX_PATH,
-          {
-            unique: false,
-          }
-        );
+    if (
+      oldVersion <= 5 &&
+      !db.objectStoreNames.contains(URL_TO_ITEM_NOTE_STORE_NAME)
+    ) {
+      db.createObjectStore(URL_TO_ITEM_NOTE_STORE_NAME, {
+        keyPath: KEY_PATH,
+      });
+      tx.objectStore(URL_TO_ITEM_NOTE_STORE_NAME).createIndex(
+        FILE_PATH_INDEX_PATH,
+        FILE_PATH_INDEX_PATH,
+        {
+          unique: false,
+        }
+      );
     }
   };
 }


### PR DESCRIPTION
Fix for #83.

This was happening because the store creation was only happening if previous db version was exactly 4. The new behavior is to only create the store if it does not already exist and version number is less than 5... did this so that existing new installs (which are all broken) will be automatically fixed.