### PR TITLE
Better handling of finding a non-file when resolving item note

### DIFF
--- a/src/ItemNote.ts
+++ b/src/ItemNote.ts
@@ -4,6 +4,7 @@ import {
   normalizePath,
   Notice,
   TFile,
+  TFolder,
   Vault,
   Workspace,
 } from "obsidian";
@@ -104,7 +105,22 @@ export const resolveItemNote =
       );
       if (file instanceof TFile) {
         return file;
+      } else if (file instanceof TFolder) {
+        log.warn(
+          `URL to Pocket item note index inconsistent: got folder instead of
+          file at path ${urlToPocketItemNoteEntry.file_path} for URL
+          ${item.resolved_url}. Was the Pocket item note moved while
+          obsidian-pocket was inactive?`
+        );
+      } else if (file === null) {
+        log.warn(
+          `URL to Pocket item note index inconsistent: could not find any file
+          at path ${urlToPocketItemNoteEntry.file_path} for URL
+          ${item.resolved_url}. Was the Pocket item note moved while
+          obsidian-pocket was inactive?`
+        );
       } else {
+        log.error(file);
         throw new Error(
           `got non-file result from vault for URL ${item.resolved_url}`
         );


### PR DESCRIPTION
The old behavior was to raise an error, which would prevent the Pocket item list from displaying if filenames found in the URL to Pocket item note index could not actually be resolved to a file in the Obsidian vault. Now, instead, an error is logged to console and those Pocket item notes remain unresolved.