### PR TITLE
Better defaults for Pocket item notes

### DIFF
--- a/src/ItemNote.ts
+++ b/src/ItemNote.ts
@@ -232,6 +232,19 @@ const openItemNote = async (workspace: Workspace, existingItemNote: TFile) => {
   await workspace.activeLeaf.openFile(existingItemNote);
 };
 
+const DEFAULT_TEMPLATE = `
+---
+Title: "{{title}}"
+URL: {{url}}
+Tags: [pocket, {{tags-no-hash}}]
+Excerpt: >
+    {{excerpt}}
+---
+{{url}}
+{{tags}}
+{{image}}
+`;
+
 export const createOrOpenItemNote =
   (
     settingsManager: SettingsManager,
@@ -256,7 +269,7 @@ export const createOrOpenItemNote =
           settingsManager.getSetting("item-note-template");
         const templateContents = templateSetting
           ? await loadTemplate(vault, metadataCache)(templateSetting)
-          : "";
+          : DEFAULT_TEMPLATE;
         const fullpath = fullpathForPocketItem(settingsManager, pocketItem);
 
         ensureFolderExists(vault, getItemNotesFolder(settingsManager));

--- a/src/ItemNote.ts
+++ b/src/ItemNote.ts
@@ -25,8 +25,10 @@ import {
 } from "./Tags";
 import { ensureFolderExists, getPocketItemPocketURL } from "./utils";
 
+const DEFAULT_ITEM_NOTES_FOLDER = "/";
+
 const getItemNotesFolder = (settingsManager: SettingsManager) =>
-  settingsManager.getSetting("item-notes-folder") ?? "/";
+  settingsManager.getSetting("item-notes-folder") ?? DEFAULT_ITEM_NOTES_FOLDER;
 
 export const displayTextForSavedPocketItem = (item: SavedPocketItem) => {
   if (!item.resolved_title && !item.resolved_url) {


### PR DESCRIPTION
- Adding a better default template than blank file
- Making default item notes folder explicit

These changes are in preparation for bulk creation of Pocket item notes, and takes care of the cases where either the Pocket item note template or Pocket item notes folder settings are not specified.
