### PR TITLE
Display Pocket-Highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ following variables are supported:
 | `{{tags-no-hash}}` | The Pocket tags for the Pocket item                     |
 | `{{tags}}`         | The Pocket tags for the Pocket item, with "#" prepended |
 | `{{image}}`        | The main image for the Pocket item                      |
+| `{{highlights}}`   | The highlighted areas of your Pocket item as list       |
 
 This is the default template in obsidian-pocket. It will populate the [YAML
 frontmatter](https://help.obsidian.md/Advanced+topics/YAML+front+matter) of the

--- a/src/ItemNote.ts
+++ b/src/ItemNote.ts
@@ -13,6 +13,7 @@ import {
   URLToPocketItemNoteIndex,
 } from "./data/URLToPocketItemNoteIndex";
 import {
+  Highlight,
   PocketTags,
   pocketTagsToPocketTagList,
   SavedPocketItem,
@@ -205,6 +206,12 @@ const generateInitialItemNoteContents = (
       tags
     );
 
+  const normalizeHighlights = (highlights?: Highlight[]) => {
+    if (!highlights) return "No Highlights";
+
+    return `${highlights.map((h) => `- ${h.quote}`).join("\n")}`;
+  };
+
   const substitutions: Map<string, SubstitutionFn> = new Map([
     ["title", (item) => normalizeTitle(item.resolved_title) ?? "Untitled"],
     ["url", (item) => item.resolved_url ?? "Missing URL"],
@@ -219,6 +226,7 @@ const generateInitialItemNoteContents = (
         return image_src ? `![image](${image_src})` : "";
       },
     ],
+    ["highlights", (item) => normalizeHighlights(item.annotations)],
   ]);
 
   return Array.from(substitutions.entries()).reduce((acc, currentValue) => {
@@ -275,6 +283,9 @@ Excerpt: >
 ---
 {{tags}}
 {{image}}
+
+### Highlights
+{{highlights}}
 `;
 
 const loadTemplateContents = async (

--- a/src/pocket_api/PocketAPI.ts
+++ b/src/pocket_api/PocketAPI.ts
@@ -78,7 +78,7 @@ export const getRequestToken: GetRequestToken = async (authRedirectURI) => {
   const REQUEST_TOKEN_URL = "https://getpocket.com/v3/oauth/request";
 
   const responseBody = await doRequest(REQUEST_TOKEN_URL, {
-    consumer_key: CONSUMER_KEY,
+    consumer_key: "78809-9423d8c743a58f62b23ee85c",
     redirect_uri: authRedirectURI,
   });
 
@@ -99,7 +99,7 @@ export const getAccessToken: GetAccessToken = async () => {
   const ACCESS_TOKEN_URL = "https://getpocket.com/v3/oauth/authorize";
 
   const responseBody = await doRequest(ACCESS_TOKEN_URL, {
-    consumer_key: CONSUMER_KEY,
+    consumer_key: "78809-9423d8c743a58f62b23ee85c",
     code: storedRequestToken,
   });
 
@@ -128,13 +128,14 @@ export const getPocketItems: GetPocketItems = async (
   const nextTimestamp = Math.floor(Date.now() / 1000);
 
   const requestOptions = {
-    consumer_key: CONSUMER_KEY,
+    consumer_key: "78809-9423d8c743a58f62b23ee85c",
     access_token: accessToken,
     since: !!lastUpdateTimestamp
       ? new Number(lastUpdateTimestamp).toString()
       : null,
     detailType: "complete",
     tag: pocketSyncTag,
+    annotations: "1",
   };
 
   if (!!lastUpdateTimestamp) {

--- a/src/pocket_api/PocketAPITypes.ts
+++ b/src/pocket_api/PocketAPITypes.ts
@@ -31,6 +31,15 @@ export interface Image {
   src: string;
 }
 
+export interface Highlight {
+  annotation_id: string;
+  created_at: string;
+  item_id: string;
+  patch: string;
+  quote: string;
+  version: string;
+}
+
 export interface SavedPocketItem extends BasePocketItem {
   status: PocketItemStatus.Unread | PocketItemStatus.Archived;
   resolved_title: string;
@@ -38,6 +47,7 @@ export interface SavedPocketItem extends BasePocketItem {
   excerpt: string;
   tags: PocketTags;
   image?: Image;
+  annotations?: Highlight[];
 }
 
 export const pocketTagsToPocketTagList = (tags: PocketTags): PocketTag[] =>


### PR DESCRIPTION
Implemented the necessary code to display highlighted areas of a pocket item. To make it work I needed to use a static `CONSUMER_KEY` which allows the return of the annotations-Array within the response. 

Fixes: #106 

TODO:
- [ ] The ordering of the highlights should reflect the read-direction (first highlight should be the top-most highlight in the pocket item)
- [ ] Test across devices
