### PR TITLE
Fix if empty getSetting of item-notes-folder

### DIFF
--- a/src/ItemNote.ts
+++ b/src/ItemNote.ts
@@ -35,7 +35,7 @@ const DEFAULT_ITEM_NOTES_FOLDER = "/";
 const MAXIMUM_TITLE_LENGTH = 255 - 8;
 
 const getItemNotesFolder = (settingsManager: SettingsManager) =>
-  settingsManager.getSetting("item-notes-folder").replace(/\/+$/, "") ??
+  settingsManager.getSetting("item-notes-folder")?.replace(/\/+$/, "") ??
   DEFAULT_ITEM_NOTES_FOLDER;
 
 export const displayTextForSavedPocketItem = (item: SavedPocketItem) => {

--- a/src/ItemNote.ts
+++ b/src/ItemNote.ts
@@ -23,7 +23,7 @@ import {
   MultiWordTagConversion,
   TagNormalizationFn,
 } from "./Tags";
-import { ensureFolderExists, getPocketItemPocketURL } from "./utils";
+import { ensureFolderExists, getPocketItemPocketURL } from "./Utils";
 
 const DEFAULT_ITEM_NOTES_FOLDER = "/";
 

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -1,7 +1,7 @@
 import update from "immutability-helper";
 import { CallbackId, CallbackRegistry } from "./CallbackRegistry";
 import { MultiWordTagConversion } from "./Tags";
-import { getUniqueId } from "./utils";
+import { getUniqueId } from "./Utils";
 
 export interface PocketSettings {
   "item-note-template"?: string;

--- a/src/data/PocketItemStore.ts
+++ b/src/data/PocketItemStore.ts
@@ -8,7 +8,7 @@ import {
   PocketItemRecord,
   SavedPocketItem,
 } from "../pocket_api/PocketAPITypes";
-import { getUniqueId } from "../utils";
+import { getUniqueId } from "../Utils";
 import { ITEM_STORE_NAME, PocketIDB, PocketIDBUpgradeFn } from "./PocketIDB";
 
 export type OnChangeCallback = () => Promise<void>;

--- a/src/data/URLToPocketItemNoteIndex.ts
+++ b/src/data/URLToPocketItemNoteIndex.ts
@@ -3,7 +3,7 @@ import log from "loglevel";
 import { EventRef, MetadataCache, Vault } from "obsidian";
 import { CallbackId, CallbackRegistry } from "src/CallbackRegistry";
 import { SettingsManager } from "src/SettingsManager";
-import { getUniqueId } from "src/utils";
+import { getUniqueId } from "src/Utils";
 import {
   PocketIDB,
   PocketIDBUpgradeFn,

--- a/src/pocket_api/PocketAPI.ts
+++ b/src/pocket_api/PocketAPI.ts
@@ -3,7 +3,7 @@ import { Notice, request } from "obsidian";
 import * as qs from "query-string";
 import { PocketGetItemsResponse } from "./PocketAPITypes";
 import { SupportedPlatform } from "../Types";
-import { getPlatform } from "../utils";
+import { getPlatform } from "../Utils";
 
 export type ResponseBody = string;
 

--- a/src/pocket_api/PocketAuth.ts
+++ b/src/pocket_api/PocketAuth.ts
@@ -5,7 +5,7 @@ import {
   PocketAPI,
   RequestToken,
 } from "./PocketAPI";
-import { openBrowserWindow } from "../utils";
+import { openBrowserWindow } from "../Utils";
 
 export type AccessInfo = AccessTokenResponse;
 

--- a/src/ui/components/PocketItem.tsx
+++ b/src/ui/components/PocketItem.tsx
@@ -13,7 +13,7 @@ import {
   getPlatform,
   getPocketItemPocketURL,
   openBrowserWindow,
-} from "src/utils";
+} from "src/Utils";
 import {
   PocketTag,
   pocketTagsToPocketTagList,


### PR DESCRIPTION
Today I start using this plugin to sync obsidian with my pocket account.
As I am not use any special folder for Pocket note, I leave the correspondent setting as default (blank).
But I found that the initial configuration will get error every time this plugin try to create a new note from a pocket link.

**Reproduce step**:
- Fresh install this plugin
- Connect your account to pocket
- Open pocket list
- Click any pocket title will throw this error:
![image](https://user-images.githubusercontent.com/13470318/227218119-66a3c23f-ec39-40b9-84e7-f749d031e582.png)

So I start digging locally, and create this fix. It is working well now using my fork. 

**Additional Notes**
Along the way of fixing I found wrong reference import to "utils" module, which apparently in the code base the module name is actually "Utils". I don't know if this is a typo or something else but I fix it nonetheless.

Do you think this fix is relevant or not? probably you could merge it to the upstream.

PS: Nice works from you, I will probably use this plugin in daily basis and maybe will help along the way.
