### PR TITLE
Fix: default template frontmatter being not recognizable

### DIFF
--- a/src/ItemNote.ts
+++ b/src/ItemNote.ts
@@ -264,8 +264,7 @@ const openItemNote = async (workspace: Workspace, existingItemNote: TFile) => {
   await workspace.activeLeaf.openFile(existingItemNote);
 };
 
-const DEFAULT_TEMPLATE = `
----
+const DEFAULT_TEMPLATE = `---
 Title: "{{title}}"
 URL: {{url}}
 Pocket URL: {{pocket-url}}


### PR DESCRIPTION
The new line at the beginning makes md parser assume the frontmatter as the content of the pages.
The files are now correctly recognized and frontmatter is rendered properly in obsidian.